### PR TITLE
Serve static assets in worker

### DIFF
--- a/worker/global.d.ts
+++ b/worker/global.d.ts
@@ -6,3 +6,7 @@ interface D1PreparedStatement {
   run(): Promise<any>;
   all(): Promise<{ results: any[] }>;
 }
+
+interface Fetcher {
+  fetch(request: Request): Promise<Response>;
+}

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -1,5 +1,6 @@
 export interface Env {
   DB: D1Database;
+  ASSETS: Fetcher;
 }
 
 interface EventRecord {
@@ -107,6 +108,6 @@ export default {
       return jsonResponse(results.map((r: any) => ({ person: r.person, anger: r.anger })));
     }
 
-    return new Response('Not Found', { status: 404 });
+    return env.ASSETS.fetch(request);
   },
 };

--- a/worker/wrangler.toml
+++ b/worker/wrangler.toml
@@ -11,3 +11,4 @@ database_name = "grudges"
 [site]
 bucket = "dist/site"
 entry-point = "."
+binding = "ASSETS"


### PR DESCRIPTION
## Summary
- expose the `ASSETS` binding to the worker runtime
- return `env.ASSETS.fetch(request)` so `/` resolves to `index.html`

## Testing
- `node -v`
- `npm -v`


------
https://chatgpt.com/codex/tasks/task_e_685cd3913db083309e15cb0b6584a4db